### PR TITLE
Fix Linux Build by updating workaround for broken GH runners

### DIFF
--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -32,10 +32,14 @@ jobs:
         sudo apt -y update
         sudo apt -y install qgis-dev
 
-    # workaround for broken clang on ubuntu runner until https://github.com/actions/runner-images/issues/8659 get fixed
-    - uses: mjp41/workaround8649@7929373c0fe5caf844d8115adccef39e3b5362e7
-      with:
-        os: ubuntu-latest
+    # Workaround for incompatible clang and libstc++ versions, see
+    # <https://github.com/actions/runner-images/issues/8659> for more info.
+    # The basic idea here is to remove g++ 13 and its C++ standard library
+    # and replace that with a compatible version of libstdc++.
+    - name: Workaround for GHA runner images issue 8659
+      run: |
+        sudo apt-get purge -y g++-13 gcc-13 libstdc++-13-dev
+        sudo apt-get install -y --allow-downgrades libstdc++-12-dev libstdc++6=12.* libgcc-s1=12.*
 
     - name: Set reusable strings
       id: strings


### PR DESCRIPTION
See <https://github.com/actions/runner-images/issues/8659> for
more information. Currently, Clang and libstdc++ provided by the
GitHub Actions runner image are incompatible. The basic idea of
this workaround is to remove the incompatible g++ 13 and its C++
standard library and replace that with a compatible version of
libstdc++.