### PR TITLE
Fix Issues with QGIS Versions <3.22

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.16)
 
 project(
   QgisHelloWorldPlugin

--- a/src/qgis_hello_world.cpp
+++ b/src/qgis_hello_world.cpp
@@ -1,12 +1,26 @@
 #include "qgis_hello_world.h"
 
+
+
+namespace {
+   const QString s_name = QStringLiteral("Hello World Plugin");
+   const QString s_description = QStringLiteral("Sample Plugin");
+   const QString s_category = QStringLiteral("Plugins");
+   const QString s_version = QStringLiteral("Version 1.2.3");
+   const QString s_icon =  QStringLiteral( ":/plugin.svg" );
+   const QgisPlugin::PluginType s_type = QgisPlugin::UI;
+}
+
 QGISEXTERN QgisPlugin* classFactory(QgisInterface* qgis_if)
 {
    std::cout << "::classFactory" << std::endl;
    return new HelloWorldPlugin(qgis_if);
 }
 
-
+// See QGIS breaking change introduced qith QGIS 3.22:
+// https://github.com/qgis/QGIS/commit/b3c5cf8d5fc1fdc289f1449df548acf9268140c6
+#if _QGIS_VERSION_INT >= 32200
+// Receny versions of QGIS use pointer to strings to pass the plugin information.
 QGISEXTERN const QString* name() {
    return &s_name;
 }
@@ -19,16 +33,38 @@ QGISEXTERN const QString* category() {
    return &s_category;
 }
 
-QGISEXTERN int type() {
-   return s_type;
-}
-
 QGISEXTERN const QString* version() {
    return &s_version;
 }
 
 QGISEXTERN const QString* icon() {
    return &s_icon;
+}
+#else
+// Older versions of QGIS return the plugin names as copies.
+QGISEXTERN const QString name() {
+   return s_name;
+}
+
+QGISEXTERN const QString description() {
+   return s_description;
+}
+
+QGISEXTERN const QString category() {
+   return s_category;
+}
+
+QGISEXTERN const QString version() {
+   return s_version;
+}
+
+QGISEXTERN const QString icon() {
+   return s_icon;
+}
+#endif
+
+QGISEXTERN int type() {
+   return s_type;
 }
 
 QGISEXTERN void unload(QgisPlugin* plugin) {
@@ -50,6 +86,10 @@ void HelloWorldPlugin::initGui() {
    // add an action to the menu
    m_menu_action = new QAction(QIcon(""), QString("Hello World"), this);
    connect(m_menu_action, SIGNAL(triggered()), this, SLOT(menu_button_action()));
+   if (m_qgis_if == nullptr) {
+      std::cout << "failed to get the handle to QGIS" << std::endl;
+      return;
+   }
    m_qgis_if->addPluginToMenu(QString("&Hello World"), m_menu_action);
 }
 

--- a/src/qgis_hello_world.h
+++ b/src/qgis_hello_world.h
@@ -19,12 +19,6 @@
 #include <QAction>
 #include <QApplication>
 
-static const QString s_name = QStringLiteral("Hello World Plugin");
-static const QString s_description = QStringLiteral("Sample Plugin");
-static const QString s_category = QStringLiteral("Plugins");
-static const QString s_version = QStringLiteral("Version 1.2.3");
-static const QString s_icon =  QStringLiteral( ":/plugin.svg" );
-static const QgisPlugin::PluginType s_type = QgisPlugin::UI;
 
 class HelloWorldPlugin : public QObject, public QgisPlugin
 {
@@ -34,6 +28,9 @@ public:
    /// @brief Constructor.
    /// @param qgis_if The Qgis interface.
    explicit HelloWorldPlugin(QgisInterface* qgis_if);
+
+   /// @brief Destructor
+   virtual ~HelloWorldPlugin() = default;
 
    /// @brief Called when the plugin is loaded.
    virtual void initGui() override;


### PR DESCRIPTION
- In older QGIS versions, the plugin metadata was passed by value. Newer versions pass by reference.
- Solved compatibility for both versions by using a compiler switch.