### PR TITLE
Add Support for Building macOS QGIS Libraries for LTR Versions

### DIFF
--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -48,7 +48,7 @@ jobs:
     - name: Build
       run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: qgis-plugin-windows-linux-${{ matrix.c_compiler }}-${{ matrix.build_type }}
         path: ${{ github.workspace }}/**/libhelloworldplugin.so

--- a/.github/workflows/build-macos-dependencies.yaml
+++ b/.github/workflows/build-macos-dependencies.yaml
@@ -103,6 +103,7 @@ jobs:
               -DWITH_PDAL=TRUE \
               -DWITH_EPT=TRUE \
               -DCMAKE_OSX_ARCHITECTURES=x86_64 \
+              -DCMAKE_BUILD_TYPE=Debug \
               ..
 
     - name: Build QGIS
@@ -112,15 +113,17 @@ jobs:
 
     - name: Debug help
       run: |
-        cd ${{ env.BUILD_DIR }}/output/lib
+        cd ${{ env.BUILD_DIR }}
+        find . -name 'qgs3dmapsettings.h'
+        cd output/lib
         ls -la
-        cd ${{ env.BUILD_DIR }}/output/lib/qgis_3d.framework
+        cd qgis_3d.framework
         ls -la
-        cd ${{ env.BUILD_DIR }}/output/lib/qgis_3d.framework/Versions
+        cd Versions
         ls -la
-        cd ${{ env.BUILD_DIR }}/output/lib/qgis_3d.framework/Versions/${{ inputs.lib-version }}
+        cd ${{ inputs.lib-version }}
         ls -la
-        cd ${{ env.BUILD_DIR }}/output/lib/qgis_3d.framework/Versions/${{ inputs.lib-version }}/Headers || true
+        cd Headers || true
         ls -la
 
     - name: Copy the built headers to the already existing libraries

--- a/.github/workflows/build-macos-dependencies.yaml
+++ b/.github/workflows/build-macos-dependencies.yaml
@@ -62,17 +62,22 @@ jobs:
     - name: Copy pre-built libraries
       run: |
         mkdir -p ${{ env.OUT_DIR }}/${{ env.LIB_PATH }}
-        cp -v -R /Volumes/QGIS.app/QGIS.app/Contents/Frameworks/qgis_3d.framework ${{ env.OUT_DIR }}/${{ env.LIB_PATH }}
-        cp -R /Volumes/QGIS.app/QGIS.app/Contents/Frameworks/qgis_analysis.framework ${{ env.OUT_DIR }}/${{ env.LIB_PATH }}
-        cp -R /Volumes/QGIS.app/QGIS.app/Contents/Frameworks/qgis_core.framework ${{ env.OUT_DIR }}/${{ env.LIB_PATH }}
-        cp -R /Volumes/QGIS.app/QGIS.app/Contents/Frameworks/qgis_gui.framework ${{ env.OUT_DIR }}/${{ env.LIB_PATH }}
-        cp -R /Volumes/QGIS.app/QGIS.app/Contents/Frameworks/qgis_native.framework ${{ env.OUT_DIR }}/${{ env.LIB_PATH }}
+
+        if [ ${{ inputs.release-channel }} == "pr" ]; then
+            QGIS_DIR_NAME="QGIS.app"
+        else
+            QGIS_DIR_NAME="QGIS-LTR.app"
+        fi
+
+        cp -v -R /Volumes/$QGIS_DIR_NAME/$QGIS_DIR_NAME/Contents/Frameworks/qgis_3d.framework ${{ env.OUT_DIR }}/${{ env.LIB_PATH }}
+        cp -R /Volumes/$QGIS_DIR_NAME/$QGIS_DIR_NAME/Contents/Frameworks/qgis_analysis.framework ${{ env.OUT_DIR }}/${{ env.LIB_PATH }}
+        cp -R /Volumes/$QGIS_DIR_NAME/$QGIS_DIR_NAME/Contents/Frameworks/qgis_core.framework ${{ env.OUT_DIR }}/${{ env.LIB_PATH }}
+        cp -R /Volumes/$QGIS_DIR_NAME/$QGIS_DIR_NAME/Contents/Frameworks/qgis_gui.framework ${{ env.OUT_DIR }}/${{ env.LIB_PATH }}
+        cp -R /Volumes/$QGIS_DIR_NAME/$QGIS_DIR_NAME/Contents/Frameworks/qgis_native.framework ${{ env.OUT_DIR }}/${{ env.LIB_PATH }}
         cd ${{ env.OUT_DIR }}/${{ env.LIB_PATH }}
         ls -la
 
-    - name: Unmount official QGIS
-      run: |
-        hdiutil detach /Volumes/QGIS.app/
+        hdiutil detach /Volumes/$QGIS_DIR_NAME/
 
     - name: Download Qt
       run: |

--- a/.github/workflows/build-macos-dependencies.yaml
+++ b/.github/workflows/build-macos-dependencies.yaml
@@ -111,21 +111,6 @@ jobs:
         cd ${{ env.BUILD_DIR }}
         make -j $(sysctl -n hw.ncpu)
 
-    - name: Debug help
-      run: |
-        cd ${{ env.BUILD_DIR }}
-        find . -name 'qgs3dmapsettings.h'
-        cd output/lib
-        ls -la
-        cd qgis_3d.framework
-        ls -la
-        cd Versions
-        ls -la
-        cd ${{ inputs.lib-version }}
-        ls -la
-        cd Headers || true
-        ls -la
-
     - name: Copy the built headers to the already existing libraries
       run: |
         cp -v -R ${{ env.BUILD_DIR }}/output/lib/qgis_3d.framework/Versions/${{ inputs.lib-version }}/Headers ${{ env.OUT_DIR }}/${{ env.LIB_PATH }}/qgis_3d.framework

--- a/.github/workflows/build-macos-dependencies.yaml
+++ b/.github/workflows/build-macos-dependencies.yaml
@@ -137,6 +137,7 @@ jobs:
         cp -v -R ${{ env.BUILD_DIR }}/src/ui/*.h ${{ env.OUT_DIR }}/${{ env.SRC_PATH }}/ui
 
     - uses: actions/upload-artifact@v4
+      if: ${{ always() }}
       with:
         name: qgis-macos-libraries-${{ inputs.qgis-version }}_${{ inputs.build-timestamp }}
         path: ${{ env.OUT_DIR }}

--- a/.github/workflows/build-macos-dependencies.yaml
+++ b/.github/workflows/build-macos-dependencies.yaml
@@ -114,7 +114,9 @@ jobs:
       run: |
         cd ${{ env.BUILD_DIR }}/output/lib
         ls -la
-        cd ${{ env.BUILD_DIR }}/output/lib/qgis_3d.framework/Versions/
+        cd ${{ env.BUILD_DIR }}/output/lib/qgis_3d.framework
+        ls -la
+        cd ${{ env.BUILD_DIR }}/output/lib/qgis_3d.framework/Versions
         ls -la
         cd ${{ env.BUILD_DIR }}/output/lib/qgis_3d.framework/Versions/${{ inputs.lib-version }}
         ls -la

--- a/.github/workflows/build-macos-dependencies.yaml
+++ b/.github/workflows/build-macos-dependencies.yaml
@@ -103,7 +103,7 @@ jobs:
               -DWITH_PDAL=TRUE \
               -DWITH_EPT=TRUE \
               -DCMAKE_OSX_ARCHITECTURES=x86_64 \
-              -DCMAKE_BUILD_TYPE=Debug \
+              -DCMAKE_BUILD_TYPE=RelWithDebInfo \
               ..
 
     - name: Build QGIS

--- a/.github/workflows/build-macos-dependencies.yaml
+++ b/.github/workflows/build-macos-dependencies.yaml
@@ -110,6 +110,17 @@ jobs:
         cd ${{ env.BUILD_DIR }}
         make -j $(sysctl -n hw.ncpu)
 
+    - name: Debug help
+      run: |
+        cd ${{ env.BUILD_DIR }}/output/lib
+        ls -la
+        cd ${{ env.BUILD_DIR }}/output/lib/qgis_3d.framework/Versions/
+        ls -la
+        cd ${{ env.BUILD_DIR }}/output/lib/qgis_3d.framework/Versions/${{ inputs.lib-version }}
+        ls -la
+        cd ${{ env.BUILD_DIR }}/output/lib/qgis_3d.framework/Versions/${{ inputs.lib-version }}/Headers || true
+        ls -la
+
     - name: Copy the built headers to the already existing libraries
       run: |
         cp -v -R ${{ env.BUILD_DIR }}/output/lib/qgis_3d.framework/Versions/${{ inputs.lib-version }}/Headers ${{ env.OUT_DIR }}/${{ env.LIB_PATH }}/qgis_3d.framework

--- a/.github/workflows/build-macos-dependencies.yaml
+++ b/.github/workflows/build-macos-dependencies.yaml
@@ -25,7 +25,9 @@ on:
       build-timestamp:
         description: "The QGIS build timestamp (you can find it here: `https://download.qgis.org/downloads/macos/pr/`)."
         default: '20240517_122510'
-        
+      release-channel:
+        description: "The QGIS release channel to use (either `pr` or `ltr`)."
+        default: 'pr'
 
 env:
   QT_VERSION: 5.15.2
@@ -47,11 +49,8 @@ jobs:
         ref: final-${{ inputs.qgis-version }}
 
     - name: Download the Official QGIS Release
-      # use a wildcard for the build date, as the build date is not known
       run: |
-        wget -O qgis_installer.dmg https://download.qgis.org/downloads/macos/pr/qgis_pr_final-${{ inputs.qgis-version }}_${{ inputs.build-timestamp }}.dmg
-
-      # wget -O qgis_installer.dmg -r --no-parent -A 'qgis_pr_final-${{ inputs.qgis-version }}_*.dmg' https://download.qgis.org/downloads/macos/pr/
+        wget -O qgis_installer.dmg https://download.qgis.org/downloads/macos/${{ inputs.release-channel }}/qgis_${{ inputs.release-channel }}_final-${{ inputs.qgis-version }}_${{ inputs.build-timestamp }}.dmg
 
     - name: Mount Official QGIS
       # To bypass EULA, we convert to cdr format.

--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -48,7 +48,7 @@ jobs:
         cd build
         make -j $(sysctl -n hw.ncpu)
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: qgis-plugin-macos-${{ matrix.qgis_version }}
         path: build/**/libhelloworldplugin.so

--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -48,7 +48,7 @@ jobs:
     - name: Build
       run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config Release
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: qgis-${{ matrix.qgis_version }}-plugin-windows
         path: ${{ steps.strings.outputs.build-output-dir }}/**/helloworldplugin.dll


### PR DESCRIPTION
This PR enhances the CI build job that generates the plugin dependencies for macOS to also support building LTR QGIS dependencies.
It adds configuration parameters to the GitHub action that allows selecting between `ltr` and `pr` releases.

This is a precondition to be able to build plugins for macOS LTR QGIS versions.