### PR TITLE
Support QGIS 4.x versions Built using Qt6

### DIFF
--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -13,21 +13,23 @@ jobs:
       fail-fast: false
       matrix:
         build_config:
-          - { qgis_version: 3.20.0-1, release: rel }
-          - { qgis_version: 3.28.3-1, release: rel }
-          - { qgis_version: 3.34.0-1, release: rel }
-          - { qgis_version: 3.34.1-1, release: rel }
-          - { qgis_version: 3.36.2-1, release: rel }
-          - { qgis_version: 3.36.3-1, release: rel }
-          - { qgis_version: 3.38.0-1, release: rel }
-          - { qgis_version: 3.38.3-1, release: rel }
-          - { qgis_version: 3.40.0-1, release: rel }
-          - { qgis_version: 3.40.2-1, release: rel }
-          - { qgis_version: 3.40.3-1, release: rel }
-          - { qgis_version: 3.44.9-2, release: ltr }
+          - { qgis_version: 3.20.0-1, release: rel, qt_version: 5 }
+          - { qgis_version: 3.28.3-1, release: rel, qt_version: 5 }
+          - { qgis_version: 3.34.0-1, release: rel, qt_version: 5 }
+          - { qgis_version: 3.34.1-1, release: rel, qt_version: 5 }
+          - { qgis_version: 3.36.2-1, release: rel, qt_version: 5 }
+          - { qgis_version: 3.36.3-1, release: rel, qt_version: 5 }
+          - { qgis_version: 3.38.0-1, release: rel, qt_version: 5 }
+          - { qgis_version: 3.38.3-1, release: rel, qt_version: 5 }
+          - { qgis_version: 3.40.0-1, release: rel, qt_version: 5 }
+          - { qgis_version: 3.40.2-1, release: rel, qt_version: 5 }
+          - { qgis_version: 3.40.3-1, release: rel, qt_version: 5 }
+          - { qgis_version: 3.44.9-2, release: ltr, qt_version: 5 }
+          - { qgis_version: 4.0.1-2, release: rel, qt_version: 6 }
     env:
       EXT_OSGEO4W_ROOT: "C:/OSGeo4W"
       Qt5_DIR: "C:/OSGeo4W/apps/Qt5"
+      Qt6_DIR: "C:/OSGeo4W/apps/Qt6"
 
     steps:
     - uses: actions/checkout@v4
@@ -63,6 +65,12 @@ jobs:
       run: |
         $exe = 'osgeo4w-setup.exe'
         $url = 'https://download.osgeo.org/osgeo4w/v2/' + $exe
+        $qtVersion = '${{ matrix.build_config.qt_version }}'
+        $qtPackages = switch ($qtVersion) {
+          '6' { 'qt6-devel,qt6-libs,qt6-tools' }
+          default { 'qt5-devel,qt5-libs,qt5-tools,qt5-libs-symbols' }
+        }
+
         Invoke-WebRequest -Uri $url -OutFile $exe
         Start-Process ('.\' + $exe) -ArgumentList @(
           '--advanced',
@@ -71,7 +79,7 @@ jobs:
           '--only-site',
           '-R', $env:EXT_OSGEO4W_ROOT,
           '-s', 'https://download.osgeo.org/osgeo4w/v2/',
-          '-P', 'qt5-devel,qt5-libs,qt5-tools,qt5-libs-symbols'
+          '-P', $qtPackages
         ) -Wait -NoNewWindow
 
     - name: Set reusable strings
@@ -85,13 +93,14 @@ jobs:
       run: |
         Add-Content $env:GITHUB_PATH "$env:EXT_OSGEO4W_ROOT/bin"
         Add-Content $env:GITHUB_PATH "$env:Qt5_DIR/bin"
+        Add-Content $env:GITHUB_PATH "$env:Qt6_DIR/bin"
 
     - name: Configure CMake
       shell: pwsh
       run: |
         $Env:OSGEO4W_ROOT = $env:EXT_OSGEO4W_ROOT
         $Env:OSGEO4W_QGIS_SUBDIR = '${{ steps.qgis-package.outputs.qgis-subdir }}'
-        cmake -B ${{ steps.strings.outputs.build-output-dir }} -S ${{ github.workspace }} -DQt5_DIR="$env:Qt5_DIR"
+        cmake -B ${{ steps.strings.outputs.build-output-dir }} -S ${{ github.workspace }} -DQt5_DIR="$env:Qt5_DIR" -DQt6_DIR="$env:Qt6_DIR"
 
     - name: Build
       run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config Release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,32 +16,27 @@ endif()
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Enable Qt-specific extensions
-set(CMAKE_AUTOMOC ON)
-set(CMAKE_AUTORCC ON)
+
+
 
 find_package(QGIS REQUIRED)
+
+# Try to find Qt5 or 6, whichever is available.
+find_package(Qt6 COMPONENTS Core Widgets Xml Gui )
+if (NOT Qt6_FOUND)
+  # Fall back to Qt5 if Qt6 is not found.
+  find_package(Qt5 5 REQUIRED COMPONENTS Core Widgets Xml Gui REQUIRED)
+
+  # Enable Qt5-specific extensions
+  set(CMAKE_AUTOMOC ON)
+  set(CMAKE_AUTORCC ON)
+
+else()
+  # Enable Qt6-specific extensions
+  qt_standard_project_setup()
+endif()
+
 find_package(Qt5 COMPONENTS Core Widgets Xml Gui REQUIRED)
-
-set(LIBS
-  ${QGIS_CORE_LIBRARY}
-  ${QGIS_GUI_LIBRARY}
-  ${QGIS_ANALYSIS_LIBRARY}
-  Qt5::Core
-  Qt5::Gui
-  Qt5::Xml
-  Qt5::Widgets
-)
-
-set(INCLUDES
-  ${Boost_INCLUDE_DIRS}
-  ${CMAKE_CURRENT_BINARY_DIR}
-  ${QGIS_INCLUDE_DIR}
-)
-
-include_directories(
-  ${INCLUDES}
-)
 
 # The compiled library code is here
 add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,9 +3,17 @@ add_library(helloworldplugin MODULE
 )
 
 target_link_libraries(helloworldplugin
-  ${LIBS}
+  ${QGIS_CORE_LIBRARY}
+  ${QGIS_GUI_LIBRARY}
+  ${QGIS_ANALYSIS_LIBRARY}
+  Qt::Core
+  Qt::Gui
+  Qt::Xml
+  Qt::Widgets
 )
 
 target_include_directories(helloworldplugin PUBLIC
-  ${INCLUDES}
+  ${Boost_INCLUDE_DIRS}
+  ${CMAKE_CURRENT_BINARY_DIR}
+  ${QGIS_INCLUDE_DIR}
 )


### PR DESCRIPTION
- Switch between Qt5 or Qt6, whichever is available in the build.
- In the CI, install the dependencies for Qt6, if available.